### PR TITLE
Upgrade Ghost to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "private": true,
-  "version": "0.5.7",
+  "version": "0.5.8",
   "dependencies": {
-    "ghost": "0.5.7",
+    "ghost": "0.5.8",
     "pg": "latest"
   },
   "engines": {


### PR DESCRIPTION
I've at least verified that it installs. Check out the tag management UI that was [introduced in Ghost 0.5.8](http://dev.ghost.org/ghost-0-5-8/):

![tag-mgmt](https://cloud.githubusercontent.com/assets/11964/5807244/90b047f2-a021-11e4-9811-e309dcef2297.png)
