### PR TITLE
Add optional support for S3 file storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ Fill out the form, and you should be cooking with gas in a few seconds.
   heroku git:clone --app YOURAPPNAME
   ```
 
-- **Image uploads [are disabled](https://github.com/cobyism/ghost-on-heroku/blob/master/config.js#L22)** when deployed to Heroku, since Heroku app filesystems [aren’t meant for permanent storage](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem). If this is a problem for you, you should look into other ways to host your site. **Update:** Initial support [has landed](https://github.com/TryGhost/Ghost/commit/5c640e95f504e8a4fc638153b007034a4f3a6fcc) for supplying custom config for external storage (e.g. Amazon S3) when including Ghost as an NPM module. See [this discussion](https://github.com/TryGhost/Ghost/issues/4600) for an insight into what’s coming.
+### File uploads
+
+Heroku app filesystems [aren’t meant for permanent storage](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem), so when it comes to file uploads for a Ghost blog deployed to Heroku, you have two options:
+
+- **Configure S3 file storage.** Create an S3 bucket on Amazon AWS, and then specify your `S3_ACCESS_KEY_ID`, `S3_ACCESS_SECRET_KEY`, and `S3_BUCKET_NAME` as environment variables on Heroku’s deployment page. Once your app is up and running, you’ll be able to upload images via the Ghost UI and they’ll be stored in Amazon S3. :sparkles:
+
+- **Disable file uploads.** Leave all the S3-related environment variable fields blank on Heroku’s deployment page and file uploads will be disabled. Ghost will ask you for external URLs instead of allowing images to be uploaded. If you don’t know what S3 is, this is the option you want.
+
+_**ProTip™**: You can start off with file uploads disabled, and specify all your S3 environment variables at a later stage. You aren’t stuck with the decision you make on the original deploy. :grin:_
 
 ### How this works
 

--- a/app.json
+++ b/app.json
@@ -15,15 +15,15 @@
     },
     "S3_ACCESS_KEY_ID": {
       "description": "Set your AWS Access Key ID to enable S3 file storage. Leave blank to disable file uploads.",
-      "value": ""
+      "required": false
     },
     "S3_ACCESS_SECRET_KEY": {
       "description": "AWS Access Secret Key, if using S3 file storage.",
-      "value": ""
+      "required": false
     },
     "S3_BUCKET_NAME": {
       "description": "Name of your S3 bucket on AWS, if using S3 file storage.",
-      "value": ""
+      "required": false
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -13,8 +13,17 @@
       "description": "The URL of this Heroku app.",
       "value": "http://YOURAPPNAME.herokuapp.com"
     },
-    "S3_ACCESS_KEY_ID": { "description": "Set your AWS Access Key ID to enable S3 file storage. Leave blank to disable file uploads." },
-    "S3_ACCESS_SECRET_KEY": { "description": "AWS Access Secret Key, if using S3 file storage." },
-    "S3_BUCKET_NAME": { "description": "Name of your S3 bucket on AWS, if using S3 file storage." }
+    "S3_ACCESS_KEY_ID": {
+      "description": "Set your AWS Access Key ID to enable S3 file storage. Leave blank to disable file uploads.",
+      "value": ""
+    },
+    "S3_ACCESS_SECRET_KEY": {
+      "description": "AWS Access Secret Key, if using S3 file storage.",
+      "value": ""
+    },
+    "S3_BUCKET_NAME": {
+      "description": "Name of your S3 bucket on AWS, if using S3 file storage.",
+      "value": ""
+    }
   }
 }

--- a/app.json
+++ b/app.json
@@ -12,6 +12,9 @@
     "HEROKU_URL": {
       "description": "The URL of this Heroku app.",
       "value": "http://YOURAPPNAME.herokuapp.com"
-    }
+    },
+    "S3_ACCESS_KEY_ID": { "description": "Set your AWS Access Key ID to enable S3 file storage. Leave blank to disable file uploads." },
+    "S3_ACCESS_SECRET_KEY": { "description": "AWS Access Secret Key, if using S3 file storage." },
+    "S3_BUCKET_NAME": { "description": "Name of your S3 bucket on AWS, if using S3 file storage." }
   }
 }

--- a/config.js
+++ b/config.js
@@ -2,10 +2,12 @@
 
 var path = require('path'),
     config,
-    storageConfig;
+    fileStorage,
+    storage;
 
 if (!!process.env.S3_ACCESS_KEY_ID) {
-  storageConfig = {
+  fileStorage = true
+  storage = {
     active: 'ghost-s3',
     'ghost-s3': {
       accessKeyId:     process.env.S3_ACCESS_KEY_ID,
@@ -16,7 +18,8 @@ if (!!process.env.S3_ACCESS_KEY_ID) {
     }
   }
 } else {
-  storageConfig = false
+  fileStorage = false
+  storage = {}
 }
 
 config = {
@@ -35,7 +38,8 @@ config = {
         }
       }
     },
-    fileStorage: storageConfig,
+    fileStorage: fileStorage,
+    storage: storage,
     database: {
       client: 'postgres',
       connection: process.env.DATABASE_URL,

--- a/config.js
+++ b/config.js
@@ -4,11 +4,11 @@ var path = require('path'),
     config,
     storageConfig;
 
-if (!!process.env.S3_ACCESS_KEY) {
+if (!!process.env.S3_ACCESS_KEY_ID) {
   storageConfig = {
     active: 'ghost-s3',
     'ghost-s3': {
-      accessKeyId:     process.env.S3_ACCESS_KEY,
+      accessKeyId:     process.env.S3_ACCESS_KEY_ID,
       secretAccessKey: process.env.S3_ACCESS_SECRET_KEY,
       bucket:          process.env.S3_BUCKET_NAME,
       region:          process.env.S3_BUCKET_REGION,

--- a/config.js
+++ b/config.js
@@ -1,7 +1,23 @@
 // Ghost Configuration for Heroku
 
 var path = require('path'),
-    config;
+    config,
+    storageConfig;
+
+if (!!process.env.S3_ACCESS_KEY) {
+  storageConfig = {
+    active: 'ghost-s3',
+    'ghost-s3': {
+      accessKeyId:     process.env.S3_ACCESS_KEY,
+      secretAccessKey: process.env.S3_ACCESS_SECRET_KEY,
+      bucket:          process.env.S3_BUCKET_NAME,
+      region:          process.env.S3_BUCKET_REGION,
+      assetHost:       process.env.S3_ASSET_HOST_URL
+    }
+  }
+} else {
+  storageConfig = false
+}
 
 config = {
 
@@ -19,7 +35,7 @@ config = {
         }
       }
     },
-    fileStorage: false,
+    fileStorage: storageConfig,
     database: {
       client: 'postgres',
       connection: process.env.DATABASE_URL,

--- a/config.js
+++ b/config.js
@@ -12,9 +12,7 @@ if (!!process.env.S3_ACCESS_KEY_ID) {
     'ghost-s3': {
       accessKeyId:     process.env.S3_ACCESS_KEY_ID,
       secretAccessKey: process.env.S3_ACCESS_SECRET_KEY,
-      bucket:          process.env.S3_BUCKET_NAME,
-      region:          process.env.S3_BUCKET_REGION,
-      assetHost:       process.env.S3_ASSET_HOST_URL
+      bucket:          process.env.S3_BUCKET_NAME
     }
   }
 } else {

--- a/content/storage/ghost-s3/index.js
+++ b/content/storage/ghost-s3/index.js
@@ -1,0 +1,2 @@
+'use strict';
+module.exports = require('ghost-s3-storage');

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "version": "0.6.0",
   "dependencies": {
     "ghost": "0.6.0",
+    "ghost-s3-storage": "~0.2.1",
     "pg": "latest"
   },
   "engines": {


### PR DESCRIPTION
In version `0.6.0` of Ghost, support was added for [custom storage modules](https://github.com/TryGhost/Ghost/wiki/Using-a-custom-storage-module). This PR adds support for S3 file storage when deployed to Heroku using this new functionality. Using S3 when deploying to Heroku is completely optional. If you don’t set the `S3_ACCESS_KEY_ID` environment variable, then `fileStorage` will be set to `false`, and Ghost will simply ask for URLs instead of allowing you to upload files.

At the moment I can seem to test this branch out with a proper Heroku deploy, as the new ENV variables don’t seem to be being recognised by Heroku. Perhaps a caching issue on their end or something? I’ll try another couple of things and if all else fails I’ll probably just merge this into `master` and work it out there.

/cc @StewartJarod @tswicegood @awendt Closes https://github.com/cobyism/ghost-on-heroku/issues/9