### PR TITLE
Add AWS bucket region as config variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fill out the form, and you should be cooking with gas in a few seconds.
 
 Heroku app filesystems [aren’t meant for permanent storage](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem), so when it comes to file uploads for a Ghost blog deployed to Heroku, you have two options:
 
-- **Configure S3 file storage.** Create an S3 bucket on Amazon AWS, and then specify your `S3_ACCESS_KEY_ID`, `S3_ACCESS_SECRET_KEY`, and `S3_BUCKET_NAME` as environment variables on Heroku’s deployment page. Once your app is up and running, you’ll be able to upload images via the Ghost UI and they’ll be stored in Amazon S3. :sparkles:
+- **Configure S3 file storage.** Create an S3 bucket on Amazon AWS, and then specify your `S3_ACCESS_KEY_ID`, `S3_ACCESS_SECRET_KEY`, `S3_BUCKET_NAME` and `S3_BUCKET_REGION` as environment variables on Heroku’s deployment page. Once your app is up and running, you’ll be able to upload images via the Ghost UI and they’ll be stored in Amazon S3. :sparkles:
 
 - **Disable file uploads.** Leave all the S3-related environment variable fields blank on Heroku’s deployment page and file uploads will be disabled. Ghost will ask you for external URLs instead of allowing images to be uploaded. If you don’t know what S3 is, this is the option you want.
 

--- a/app.json
+++ b/app.json
@@ -24,6 +24,10 @@
     "S3_BUCKET_NAME": {
       "description": "Name of your S3 bucket on AWS, if using S3 file storage.",
       "required": false
+    },
+    "S3_BUCKET_REGION": {
+      "description": "Region of your S3 bucket on AWS, if using S3 file storage.",
+      "required": false
     }
   }
 }

--- a/config.js
+++ b/config.js
@@ -12,7 +12,8 @@ if (!!process.env.S3_ACCESS_KEY_ID) {
     'ghost-s3': {
       accessKeyId:     process.env.S3_ACCESS_KEY_ID,
       secretAccessKey: process.env.S3_ACCESS_SECRET_KEY,
-      bucket:          process.env.S3_BUCKET_NAME
+      bucket:          process.env.S3_BUCKET_NAME,
+      region:          process.env.S3_BUCKET_REGION
     }
   }
 } else {


### PR DESCRIPTION
First let me thank you, I was able to setup a Ghost blog on Heroku in minutes, which is a huge help and really awesome.

But I encountered a little problem with the S3 setup. Since I'm using a bucket in Europe and the default authentication scheme used by the AWS SDK is `V2` I got this [this sort of error](http://stackoverflow.com/questions/26533245/the-authorization-mechanism-you-have-provided-is-not-supported-please-use-aws4) when I tried to upload stuff in the blog. To get the AWS SDK beneath ghost-s3 to use the right authentication scheme, it is suffice to pass a `region` option to the [ghost-s3 configuration](https://www.npmjs.com/package/ghost-s3#configure). So I added another entry in `config.js` and `app.json` and updated the `README.md` accordingly.

The mentioned changes above worked at least for my setup, so if everything works on your side, you might want to include this pull request in your repository too.

Cheers 🍻
