### PR TITLE
Use SSL for the PostgreSQL connection

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,6 +32,11 @@
     "S3_ASSET_HOST_URL": {
       "description": "Optional custom CDN asset host url, if using S3 file storage.",
       "required": false
+    },
+    "PGSSLMODE": {
+      "description": "PostgreSQL SSL connection mode. Set to 'require' to force SSL. Unset it to use the default.",
+      "required": false,
+      "value": "require"
     }
   }
 }


### PR DESCRIPTION
Heroku's Postgres requires the use of SSL. Since the DATABASE_URL environment variable doesn't specify the ssl option we add it in the config.js.

Without this addition the application was crashing with the following exception:

```
2015-09-11T05:02:45.967491+00:00 heroku[web.1]: Starting process with command `npm start --production`
2015-09-11T05:02:48.724300+00:00 app[web.1]: 
2015-09-11T05:02:48.724323+00:00 app[web.1]: > ghost-on-heroku@0.6.4 start /app
2015-09-11T05:02:48.724325+00:00 app[web.1]: > node server.js
2015-09-11T05:02:48.724327+00:00 app[web.1]: 
2015-09-11T05:02:53.862256+00:00 app[web.1]: Migrations: Creating table: posts
2015-09-11T05:02:53.847087+00:00 app[web.1]: Migrations: Database initialisation required for version 003
2015-09-11T05:02:54.077474+00:00 app[web.1]:     at Connection.parseMessage (/app/node_modules/ghost/node_modules/pg/lib/connection.js:361:17)
2015-09-11T05:02:54.077486+00:00 app[web.1]:     at Socket.Readable.push (_stream_readable.js:128:10)
2015-09-11T05:02:54.077470+00:00 app[web.1]:     at Connection.parseE (/app/node_modules/ghost/node_modules/pg/lib/connection.js:534:11)
2015-09-11T05:02:54.077484+00:00 app[web.1]:     at readableAddChunk (_stream_readable.js:166:9)
2015-09-11T05:02:54.077461+00:00 app[web.1]: Unhandled rejection error: no pg_hba.conf entry for host "52.17.127.26", user "lakdsjfoaiufso", database "asdf98a7sdfo", SSL off
2015-09-11T05:02:53.861685+00:00 app[web.1]: Migrations: Creating tables...
2015-09-11T05:02:54.077487+00:00 app[web.1]:     at TCP.onread (net.js:529:21)
2015-09-11T05:02:54.077475+00:00 app[web.1]:     at Socket.<anonymous> (/app/node_modules/ghost/node_modules/pg/lib/connection.js:105:22)
2015-09-11T05:02:54.077479+00:00 app[web.1]:     at Socket.<anonymous> (_stream_readable.js:765:14)
2015-09-11T05:02:54.077477+00:00 app[web.1]:     at Socket.emit (events.js:95:17)
2015-09-11T05:02:54.077480+00:00 app[web.1]:     at Socket.emit (events.js:92:17)
2015-09-11T05:02:54.077482+00:00 app[web.1]:     at emitReadable_ (_stream_readable.js:427:10)
2015-09-11T05:02:54.077483+00:00 app[web.1]:     at emitReadable (_stream_readable.js:423:5)
2015-09-11T05:02:55.569421+00:00 heroku[web.1]: Process exited with status 0
2015-09-11T05:02:55.587922+00:00 heroku[web.1]: State changed from starting to crashed
```