### PR TITLE
better bucketeer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ To configure S3 file storage, create an S3 bucket on Amazon AWS, and then specif
 
 Once your app is up and running with these variables in place, you should be able to upload images via the Ghost interface and they’ll be stored in Amazon S3. :sparkles:
 
+##### Provisioning an S3 bucket using an add-on
+
+If you’d prefer not to configure S3 manually, you can provision the [Bucketeer add-on](https://devcenter.heroku.com/articles/bucketeer)
+to get an S3 bucket (Bucketeer starts at $5/mo).
+
+To configure S3 via Bucketeer, leave all the S3 deployment fields blank and deploy your
+Ghost blog. Once your blog is deployed, run the following commands from your terminal:
+
+    heroku addons:create bucketeer --app YOURAPPNAME
+
+The environment variables set by the add-on will be automatically detected and used to
+configure your Ghost blog and enable uploads.
+
 ### How this works
 
 This repository is essentially a minimal web application that specifies [Ghost as a dependency](https://github.com/TryGhost/Ghost/wiki/Using-Ghost-as-an-NPM-module), and makes a deploy button available.
@@ -61,7 +74,7 @@ git pull origin master # may trigger a few merge conflicts, depending on how lon
 git push heroku master
 ```
 
-This will pull down the code that was deployed to Heroku so you have it locally, attach this repository as a new remote, attempt to pull down the latest version and merge it in, and then push that change back to your Heroku app instance.  
+This will pull down the code that was deployed to Heroku so you have it locally, attach this repository as a new remote, attempt to pull down the latest version and merge it in, and then push that change back to your Heroku app instance.
 
 
 ## Problems?

--- a/config.js
+++ b/config.js
@@ -17,6 +17,18 @@ if (!!process.env.S3_ACCESS_KEY_ID) {
       assetHost:       process.env.S3_ASSET_HOST_URL
     }
   }
+} else if (!!process.env.BUCKETEER_AWS_ACCESS_KEY_ID) {
+  fileStorage = true
+  storage = {
+    active: 'ghost-s3',
+    'ghost-s3': {
+      accessKeyId:     process.env.BUCKETEER_AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.BUCKETEER_AWS_SECRET_ACCESS_KEY,
+      bucket:          process.env.BUCKETEER_BUCKET_NAME,
+      region:          process.env.S3_BUCKET_REGION,
+      assetHost:       process.env.S3_ASSET_HOST_URL
+    }
+  }
 } else {
   fileStorage = false
   storage = {}


### PR DESCRIPTION
I think we got it right this time :) 

This PR documents the add-on in the README and doesn't clobber `process.env` vars to configure S3 image storage.

Confirmed uploads and images are working in my test ghost blog.
<img width="1043" alt="screen shot 2016-01-28 at 5 49 25 pm" src="https://cloud.githubusercontent.com/assets/173457/12661424/8cf6db7a-c5e7-11e5-94f5-a54d947be4a8.png">
