### PR TITLE
Fix S3_ASSET_HOST_URL typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To configure S3 file storage, create an S3 bucket on Amazon AWS, and then specif
 
 - `S3_BUCKET_REGION`: **Required if using S3 uploads**. Specify the region the bucket has been created in, using slug format (e.g. `us-east-1`, `eu-west-1`). A full list of S3 regions is [available here](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
 
-- `S3_ASSET_HOST`: Optional, even if using S3 uploads. Use this variable to specify the S3 bucket URL in virtual host style, path style or using a custom domain. See [this page](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) for details.
+- `S3_ASSET_HOST_URL`: Optional, even if using S3 uploads. Use this variable to specify the S3 bucket URL in virtual host style, path style or using a custom domain. You should also include a trailing slash (example `https://my.custom.domain/`).  See [this page](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html) for details.
 
 Once your app is up and running with these variables in place, you should be able to upload images via the Ghost interface and they’ll be stored in Amazon S3. :sparkles:
 


### PR DESCRIPTION
The README specified an incorrect environment variable name for customizing the S3 asset host.

* Fix typo in S3_ASSET_HOST_URL environment variable
* Add example url with emphasis on adding trailing slash so that ghost image urls are generated correctly.