### PR TITLE
upgrade to Ghost 0.11.0

### DIFF
--- a/content/storage/ghost-s3/index.js
+++ b/content/storage/ghost-s3/index.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = require('ghost-s3-compat');
+module.exports = require('ghost-s3-storage-adapter');

--- a/content/storage/ghost-s3/index.js
+++ b/content/storage/ghost-s3/index.js
@@ -1,2 +1,2 @@
 'use strict';
-module.exports = require('ghost-s3-storage');
+module.exports = require('ghost-s3-compat');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
     "ghost": "~0.11.0",
-    "ghost-s3-compat": "git://github.com/aorcsik/ghost-s3-compat.git",
+    "ghost-s3-compat": "git://github.com/aorcsik/ghost-s3-storage-adapter.git#v3.0.3",
     "ncp": "^2.0.0",
     "pg": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.9.0",
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
-    "ghost": "~0.10.0-rc",
+    "ghost": "~0.10.1",
     "ghost-s3-compat": "git://github.com/aorcsik/ghost-s3-compat.git",
     "ncp": "^2.0.0",
     "pg": "latest"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.9.0",
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
-    "ghost": "~0.10.1",
+    "ghost": "~0.11.0",
     "ghost-s3-compat": "git://github.com/aorcsik/ghost-s3-compat.git",
     "ncp": "^2.0.0",
     "pg": "latest"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
     "ghost": "~0.11.0",
-    "ghost-s3-compat": "git://github.com/aorcsik/ghost-s3-storage-adapter.git#v3.0.3",
+    "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.9.0",
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
-    "ghost": "~0.11.0",
+    "ghost": "0.11.0",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "version": "0.9.0",
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
-    "ghost": "0.9.0",
-    "ghost-s3-storage": "~0.2.2",
+    "ghost": "~0.10.0-rc",
+    "ghost-s3-compat": "git://github.com/aorcsik/ghost-s3-compat.git",
     "ncp": "^2.0.0",
     "pg": "latest"
   },

--- a/server.js
+++ b/server.js
@@ -1,3 +1,6 @@
+// Temporary fix for lodash issue: https://github.com/TryGhost/Ghost/issues/7336
+require('ghost/core/server/overrides');
+
 var path = require('path');
 var ghost = require('ghost');
 

--- a/server.js
+++ b/server.js
@@ -1,6 +1,3 @@
-// Temporary fix for lodash issue: https://github.com/TryGhost/Ghost/issues/7336
-require('ghost/core/server/overrides');
-
 var path = require('path');
 var ghost = require('ghost');
 


### PR DESCRIPTION
I managed to upgrade ghost to 0.10.0, at this time the available npm module is 0.10.0-rc1, but `~0.10.0-rc` in package.json would cover the coming minor versions.

There is also a breaking change in 0.10.0, which requires custom storage adapters to conform to an interface. I forked ghost-s3-compat and added the required changes, and successfully deployed ghost 0.10.0. (There is a pull request for ghost-s3-compat that aims to fix these breaking changes: https://github.com/spanishdict/ghost-s3-compat/pull/11 )

I would consider this pull request an in progress or bridge update if someone wants to jump to the new ghost version before 0.10.0 npm module and the updated ghost-s3-compat is published.