### PR TITLE
Bump Ghost version to 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.9.0",
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
-    "ghost": "0.11.1",
+    "ghost": "0.11.2",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.11.2",
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.3",
     "ghost": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "version": "0.9.0",
   "dependencies": {
-    "Casper": "TryGhost/Casper#1.3.1",
+    "Casper": "TryGhost/Casper#1.3.3",
     "ghost": "0.11.2",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.9.0",
   "dependencies": {
     "Casper": "TryGhost/Casper#1.3.1",
-    "ghost": "0.11.0",
+    "ghost": "0.11.1",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"


### PR DESCRIPTION
* Upgrading to version 0.11.2 of Ghost
* Upgrading to version 1.3.3 of Casper

Related release notes: https://dev.ghost.org/ghost-0-11-2/