### PR TITLE
Path change

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": "~0.10.0"
   },
   "scripts": {
-    "postinstall": "ncp node_modules/Casper content/themes/casper",
+    "postinstall": "ncp node_modules/Casper content/themes/",
     "start": "node server.js"
   }
 }


### PR DESCRIPTION
removed `/casper` in the theme path

I think it was getting fussy with the dir name - this should hopefully fix it.