### PR TITLE
Use MySQL (via ClearDB)

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/cobyism/ghost-on-heroku",
   "success_url": "/ghost",
   "addons": [
-    "heroku-postgresql",
+    "cleardb",
     "mailgun"
   ],
   "env": {
@@ -32,11 +32,6 @@
     "S3_ASSET_HOST_URL": {
       "description": "Optional custom CDN asset host url, if using S3 file storage.",
       "required": false
-    },
-    "PGSSLMODE": {
-      "description": "PostgreSQL SSL connection mode. Set to 'require' to force SSL. Unset it to use the default.",
-      "required": false,
-      "value": "require"
     }
   }
 }

--- a/config.js
+++ b/config.js
@@ -52,8 +52,8 @@ config = {
     fileStorage: fileStorage,
     storage: storage,
     database: {
-      client: 'postgres',
-      connection: process.env.DATABASE_URL,
+      client: 'mysql',
+      connection: process.env.CLEARDB_DATABASE_URL,
       debug: false
     },
     server: {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "casper": "TryGhost/Casper#1.3.4",
     "ghost": "0.11.3",
     "ghost-s3-storage-adapter": "3.0.4",
-    "ncp": "^2.0.0",
-    "pg": "latest"
+    "ncp": "^2.0.0"
   },
   "engines": {
     "node": "~0.12.0"


### PR DESCRIPTION
Ghost will [drop PostgreSQL support](https://dev.ghost.org/dropping-support-for-postgresql/) in v1.0 (see #6). 

This PR switches to MySQL (via the `cleardb` addon) before the 1.0 release. Data is *not* preserved, but backups do get restored properly.