### PR TITLE
Ghost and node upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.11.3",
   "dependencies": {
     "casper": "TryGhost/Casper#1.3.4",
-    "ghost": "0.11.3",
+    "ghost": "0.11.4",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"

--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   },
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "private": true,
-  "version": "0.11.3",
+  "version": "0.11.4",
   "dependencies": {
     "casper": "TryGhost/Casper#1.3.4",
-    "ghost": "0.11.3",
+    "ghost": "0.11.4",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"
   },
   "engines": {
-    "node": "~0.12.0"
+    "node": "~4.2"
   },
   "scripts": {
     "postinstall": "ncp node_modules/casper content/themes/casper",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "version": "0.11.3",
   "dependencies": {
     "casper": "TryGhost/Casper#1.3.4",
-    "ghost": "0.11.4",
+    "ghost": "0.11.3",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "private": true,
   "version": "0.11.4",
   "dependencies": {
-    "casper": "TryGhost/Casper#1.3.4",
+    "casper": "TryGhost/Casper#1.3.5",
     "ghost": "0.11.4",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",


### PR DESCRIPTION
This changeset upgrades Ghost and Node version. This is only tested by running a deploy to Heroku which passed.