### PR TITLE
Updated to v0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   },
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "private": true,
-  "version": "0.11.3",
+  "version": "0.11.4",
   "dependencies": {
-    "casper": "TryGhost/Casper#1.3.4",
-    "ghost": "0.11.3",
+    "casper": "TryGhost/Casper#1.3.5",
+    "ghost": "0.11.4",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"
   },
   "engines": {
-    "node": "~0.12.0"
+    "node": "~4.7.3"
   },
   "scripts": {
     "postinstall": "ncp node_modules/casper content/themes/casper",


### PR DESCRIPTION
- Changed node to v4.7.x as the Argon LTS
  releases are recommended by Ghost.