### PR TITLE
Updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
   },
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "private": true,
-  "version": "0.11.8",
+  "version": "0.11.10",
   "dependencies": {
-    "casper": "TryGhost/Casper#1.3.6",
-    "ghost": "0.11.8",
+    "casper": "TryGhost/Casper#1.3.7",
+    "ghost": "0.11.10",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"
   },
   "engines": {
-    "node": "^4.2.0 || ^6.9.0"
+    "node": "^4.5.0 || ^6.9.0"
   },
   "scripts": {
     "postinstall": "ncp node_modules/casper content/themes/casper",


### PR DESCRIPTION
cf. Ghost LTS upstream: https://github.com/TryGhost/Ghost/releases/tag/0.11.10
minimum version of node 4 is now v4.5.0
new release of casper: https://github.com/TryGhost/Casper/releases