### PR TITLE
specify node versions with the latest security patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pg": "latest"
   },
   "engines": {
-    "node": "4.8.4 || 6.11.1"
+    "node": "^4.8.4 || ^6.11.1"
   },
   "scripts": {
     "postinstall": "ncp node_modules/casper content/themes/casper",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pg": "latest"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.9.0"
+    "node": "4.8.4 || 6.11.1"
   },
   "scripts": {
     "postinstall": "ncp node_modules/casper content/themes/casper",


### PR DESCRIPTION
There's a new patch out for Node that addresses a Constant Hashtable Seeds security vulnerability. I updated the package.json to make sure that existing installations of ghost-on-heroku use the new patch.