### PR TITLE
Node.js security update

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pg": "latest"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.9.0"
+    "node": "^4.8.4 || ^6.11.1"
   },
   "scripts": {
     "postinstall": "ncp node_modules/casper content/themes/casper",


### PR DESCRIPTION
The Node.js team has [announced](https://nodejs.org/en/blog/vulnerability/july-2017-security-releases/) that a high severity remote Denial of Service (DoS) Constant Hashtable Seeds vulnerability in Node.js versions 4.x through 8.x has been patched in the following versions:

4.8.4
6.11.1
7.10.1
8.1.4

Any Node.js applications affected by this vulnerability should be upgraded NOW!