### PR TITLE
Updated Ghost to 0.11.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   },
   "bugs": "https://github.com/TryGhost/Ghost/issues",
   "private": true,
-  "version": "0.11.10",
+  "version": "0.11.11",
   "dependencies": {
     "casper": "TryGhost/Casper#1.3.7",
-    "ghost": "0.11.10",
+    "ghost": "0.11.11",
     "ghost-s3-storage-adapter": "3.0.4",
     "ncp": "^2.0.0",
     "pg": "latest"


### PR DESCRIPTION
I guess it's the beginning of EOL for this repo as it is as PostgresQL support is dropped in the now released Ghost v1 :-/
