### PR TITLE
Disable update UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ This repository is a [Node.js](https://nodejs.org) web application that specifie
   * Ghost and Casper theme versions are declared in the Node app's [`package.json`](package.json)
   * Scales across processor cores in larger dynos via [Node cluster API](https://nodejs.org/dist/latest-v6.x/docs/api/cluster.html)
 
+## Custom configuration
+
+Ghost supports [configuration with environment variables](https://docs.ghost.org/docs/config#section-running-ghost-with-config-env-variables). Setting custom config is simple with Heroku. For example:
+
+```bash
+heroku config:set privacy__useUpdateCheck=false
+```
+
 ## Updating source code
 
 Optionally after deployment, to push Ghost upgrades or work with source code, clone this repo (or a fork) and connect it with the Heroku app:

--- a/bin/create-config
+++ b/bin/create-config
@@ -70,6 +70,9 @@ function createConfig() {
     },
     paths: {
       contentPath: path.join(appRoot, '/content/')
+    },
+    privacy: {
+      useUpdateCheck: false
     }
   };
 


### PR DESCRIPTION
Avoid showing the "Upgrade" button in the Ghost admin UI. It does not work as expected, because changes to the app must be deployed to Heroku (via git), not performed in-place ([Heroku filesystem is ephemeral](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem)).